### PR TITLE
fix: disable broken srt sample apps

### DIFF
--- a/ffmpeg-2204-sdk/snapcraft.yaml
+++ b/ffmpeg-2204-sdk/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
   srt:
     plugin: cmake
     source: https://github.com/Haivision/srt.git
-    source-tag: 'x1.2.0'
+    source-tag: 'v1.5.4'
     source-depth: 1
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
@@ -46,6 +46,8 @@ parts:
       - -DCMAKE_CXX_FLAGS_RELEASE=-s
       - -DENABLE_LOGGING=OFF
       - -DENABLE_STATIC=OFF
+      # FFmpeg only needs the shared library, headers, and pkg-config metadata.
+      - -DENABLE_APPS=OFF
     build-packages:
       - libssl-dev
   avisynth-plus:


### PR DESCRIPTION
## Summary
- Fixes the real build failures from https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/runs/27068272645 and the follow-up PR build.
- The original arm64 remote build reached the SRT part and failed compiling SRT 1.2.0's broken `apps/stransmit.cpp` sample application.
- The PR amd64 build then showed FFmpeg 8.1 also requires newer SRT API symbols (`SRT_TRANSTYPE`, `SRTO_TRANSTYPE`, `SRTO_PAYLOADSIZE`, etc.) that SRT 1.2.0 does not provide.
- Bump SRT to v1.5.4 and disable SRT support applications; FFmpeg only needs libsrt, headers, and pkg-config metadata.

## Verification
- `python3` YAML assertion: `parts.srt.source-tag == v1.5.4` and `parts.srt.cmake-parameters` contains `-DENABLE_APPS=OFF`.
- `git diff --check`
- `snapcraft expand-extensions` from `ffmpeg-2204-sdk/`
- Local SRT lifecycle with the updated Snapcraft cmake flags:
  - `cmake /tmp/srt-v1.5.4 ... -DENABLE_APPS=OFF`
  - `cmake --build . -j$(nproc)`
  - `DESTDIR=/tmp/srt-install-test cmake --install .`
  - confirmed `libsrt.so`, `include/srt/srt.h`, `include/srt/version.h`, and `pkgconfig/srt.pc` exist, `srt.pc` reports `Version: 1.5.4`, and `srt.h` contains `SRT_TRANSTYPE`.

@jnsgruk for review.