### PR TITLE
ci: serialize SDK release remote builds

### DIFF
--- a/.github/workflows/release-sdk-to-candidate.yml
+++ b/.github/workflows/release-sdk-to-candidate.yml
@@ -36,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: "2204 Branch"
     strategy:
+      # snapcraft remote-build pushes all matrix legs through one generated
+      # Launchpad repository/ref; serialize to avoid ref-lock races.
+      max-parallel: 1
       fail-fast: false
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}


### PR DESCRIPTION
Summary:
- Serializes the SDK release remote-build matrix with max-parallel: 1.
- Avoids concurrent snapcraft remote-build legs racing on the generated Launchpad git ref.

Evidence:
- Failed run: https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/runs/27098133862
- armhf/ppc64el failed with cannot lock ref refs/heads/main, and missing .snap review-tool errors were downstream fallout.

Verification:
- Parsed release workflow YAML with Python yaml.safe_load.
- Ran git diff --check.
- Commit is signed.

@jnsgruk for review once PR CI/release validation has signal.
