### PR TITLE
fix: clear execstack on versioned x264 library

### DIFF
--- a/ffmpeg-2204-sdk/snapcraft.yaml
+++ b/ffmpeg-2204-sdk/snapcraft.yaml
@@ -339,7 +339,9 @@ parts:
         sed -i 's#includedir=/usr#includedir=${prefix}#' $PC
       done
       if [ "$CRAFT_ARCH_TRIPLET" == "arm-linux-gnueabihf" ]; then
-        execstack --clear-execstack usr/lib/arm-linux-gnueabihf/libx264.so.164
+        x264_lib=$(find usr/lib/arm-linux-gnueabihf -maxdepth 1 -type f -name 'libx264.so.*' | sort | tail -n1)
+        test -n "$x264_lib"
+        execstack --clear-execstack "$x264_lib"
       fi
   deps:
     after: [ffmpeg, prefix-fix]


### PR DESCRIPTION
## Summary
- replace the hard-coded `libx264.so.164` execstack target with discovery of the versioned `libx264.so.*` installed for armhf
- keep the existing armhf-only execstack clearing behaviour while tolerating the x264 stable branch moving to `libx264.so.165`

## Evidence
- Release run: https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/runs/27124918541
- Failed job: Release to latest/candidate (armhf)
- Log evidence showed x264 installed `usr/local/lib/libx264.so.165`, while `override-prime` tried to clear `usr/lib/arm-linux-gnueabihf/libx264.so.164`.

## Verification
- Parsed both snapcraft files with PyYAML.
- Ran `git diff --check`.
- Exercised the replacement shell snippet with a fake armhf prime tree containing `usr/lib/arm-linux-gnueabihf/libx264.so.165`; it selected that file and invoked `execstack --clear-execstack` on it.

@jnsgruk please review. I have opened this as draft pending PR CI.
