### PR TITLE
fix: keep srt update on stable releases

### DIFF
--- a/.github/workflows/update-sdk-snap.yml
+++ b/.github/workflows/update-sdk-snap.yml
@@ -27,7 +27,7 @@ jobs:
           update-script: |
             NV_CODEC_HEADERS_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg/nv-codec-headers.git     | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.nv-codec-headers.source-tag = \"$NV_CODEC_HEADERS_VERSION\"" ffmpeg-2204-sdk/snapcraft.yaml
-            SRT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/Haivision/srt.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+            SRT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/Haivision/srt.git 'refs/tags/v[0-9]*' | grep -E 'refs/tags/v[0-9]+(\.[0-9]+)*$' | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.srt.source-tag = \"$SRT_VERSION\"" ffmpeg-2204-sdk/snapcraft.yaml
             AVISYNTH_PLUS_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/AviSynth/AviSynthPlus.git | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.avisynth-plus.source-tag = \"$AVISYNTH_PLUS_VERSION\"" ffmpeg-2204-sdk/snapcraft.yaml

--- a/ffmpeg-2204-sdk/snapcraft.yaml
+++ b/ffmpeg-2204-sdk/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
   srt:
     plugin: cmake
     source: https://github.com/Haivision/srt.git
-    source-tag: 'x1.2.0'
+    source-tag: 'v1.5.5'
     source-depth: 1
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
## Summary
- Restore `ffmpeg-2204-sdk` to a stable SRT release tag after the updater selected the historical `x1.2.0` tag.
- Filter the automated SRT lookup to stable `v*` release tags so future scheduled runs cannot sort `x1.2.0` after current releases.

## Failure evidence
- Bad updater commit: https://github.com/snapcrafters/ffmpeg-2204-sdk/commit/1423d5d1111d425e339740a406cc10b6a099ae8c
- Failed release run: https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/runs/27143208087
- The failing logs show SRT `apps/stransmit.cpp` compile errors from the old source, e.g. `error: expected unqualified-id before ‘if’`, followed by `Failed to run the build script for part 'srt'.`

## Verification
- Confirmed the old lookup sorted the historical `x1.2.0` tag after current `v1.5.x` tags.
- Confirmed the new filtered lookup resolves to `v1.5.5` and ignores `x1.2.0`.
- Ran the workflow's `yq` assignment against a throwaway snapcraft file and verified `.parts.srt.source-tag == v1.5.5`.
- Ran `snapcraft expand-extensions` for `ffmpeg-2204-sdk` and verified the expanded recipe contains `source-tag: v1.5.5` and retains `-DENABLE_APPS=OFF`.

@jnsgruk
