### PR TITLE
ci: remove release workflow max-parallel limits

### DIFF
--- a/.github/workflows/release-sdk-to-candidate.yml
+++ b/.github/workflows/release-sdk-to-candidate.yml
@@ -36,9 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: "2204 Branch"
     strategy:
-      # snapcraft remote-build pushes all matrix legs through one generated
-      # Launchpad repository/ref; serialize to avoid ref-lock races.
-      max-parallel: 1
       fail-fast: false
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}


### PR DESCRIPTION
## Summary
- Remove max-parallel limits from release-to-candidate matrix strategies.
- Drop stale serialization comments from affected release workflows.

## Validation
- Parsed all workflow YAML files with Python/PyYAML.