### PR TITLE
ci: serialize content release remote builds

### DIFF
--- a/.github/workflows/release-content-to-candidate.yml
+++ b/.github/workflows/release-content-to-candidate.yml
@@ -37,6 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: "2204 Branch"
     strategy:
+      # snapcraft remote-build pushes all matrix legs through one generated
+      # Launchpad repository/ref; serialize to avoid ref-lock races.
+      max-parallel: 1
       fail-fast: false
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}


### PR DESCRIPTION
## Summary

Serialize the `release-content-to-candidate` architecture matrix with `max-parallel: 1`, matching the SDK release workflow.

## Failure evidence

Failing workflow: https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/runs/27139997605

The content release workflow runs `snapcraft remote-build` concurrently across architectures. The full failed logs show Launchpad/Snapcraft remote-build contention rather than a snap recipe compile failure:

- `ppc64el`: `remote: error: cannot lock ref 'refs/heads/main': reference already exists`, followed by `Git operation failed with: Could not push 'HEAD' ... refspec 'refs/heads/master:refs/heads/main'`.
- `arm64`: remote-build uploaded to the same generated Launchpad repo/ref and then failed with `snapcraft internal error: BadRequest()` before any snap artifact existed.
- The later `ERROR: file 'ffmpeg-2204/ffmpeg-2204_8.1_<arch>.snap' does not exist` messages are downstream symptoms after remote-build failed to produce artifacts.

## Root cause

`snapcraft remote-build` pushes matrix legs through generated Launchpad git repositories/refs. Running those legs in parallel can race on the same Launchpad ref. The SDK workflow already has the same mitigation (`strategy.max-parallel: 1`); the content release workflow was missing it.

## Verification

- Parsed `.github/workflows/release-content-to-candidate.yml` with Python/PyYAML.
- Asserted `jobs.release-content.strategy.max-parallel == 1` and `fail-fast == false`.

## Notes

A separate `armhf` failure in the same run built and released successfully, then failed while pushing the release tag because the bot token refused a ref update involving `.github/workflows/update-sdk-snap.yml` without `workflow` scope. That appears to be a credential/scope issue, not addressed by this workflow serialization change.

@jnsgruk please review.