### PR TITLE
ci: use GITHUB_TOKEN for release tags

### DIFF
--- a/.github/workflows/release-content-to-candidate.yml
+++ b/.github/workflows/release-content-to-candidate.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 jobs:
@@ -50,7 +50,7 @@ jobs:
           multi-snap: true
           snapcraft-project-root: "ffmpeg-2204"
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }}
-          repo-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   call-for-testing:
     if: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release-sdk-to-candidate.yml
+++ b/.github/workflows/release-sdk-to-candidate.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 jobs:
@@ -48,7 +48,7 @@ jobs:
           multi-snap: true
           snapcraft-project-root: "ffmpeg-2204-sdk"
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }}
-          repo-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   call-for-testing:
     name: 📣 Create call for testing


### PR DESCRIPTION
## Summary

Use the built-in `GITHUB_TOKEN` for release workflow tag pushes instead of the `SNAPCRAFTERS_BOT_COMMIT` PAT, and grant the release workflows `contents: write` so the tag push is authorized.

## Failure evidence

Run: https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/runs/27139997605

The `Release ffmpeg-2204 to candidate` armhf matrix leg reached the post-release tag step, then failed while pushing the release tag:

```text
! [remote rejected] ffmpeg-2204-8.1/rev144/armhf -> ffmpeg-2204-8.1/rev144/armhf (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/update-sdk-snap.yml` without `workflow` scope)
```

The release composite action uses `repo-token` for checkout and the later `git push origin "$tag_name"`, so passing the bot PAT exposes the workflow-scope restriction. Using the repository `GITHUB_TOKEN` with `contents: write` should be sufficient for release tag creation and avoids requiring `workflow` scope on the bot PAT.

## Changes

- `.github/workflows/release-sdk-to-candidate.yml`
  - `permissions.contents: write`
  - `repo-token: ${{ secrets.GITHUB_TOKEN }}`
- `.github/workflows/release-content-to-candidate.yml`
  - `permissions.contents: write`
  - `repo-token: ${{ secrets.GITHUB_TOKEN }}`

No `max-parallel` changes are included.

## Verification

- Parsed both edited workflow YAML files with Python/PyYAML.
- Asserted each release workflow keeps `issues: write`, grants `contents: write`, has exactly one `snapcrafters/ci/release-to-candidate@main` step, passes `repo-token: ${{ secrets.GITHUB_TOKEN }}`, and does not contain `max-parallel`.
- Ran `git diff --check`.

@jnsgruk please review.