### PR TITLE
ci: enable fail-fast in release workflows

### DIFF
--- a/.github/workflows/release-content-to-candidate.yml
+++ b/.github/workflows/release-content-to-candidate.yml
@@ -37,7 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: "2204 Branch"
     strategy:
-      fail-fast: false
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
     steps:

--- a/.github/workflows/release-sdk-to-candidate.yml
+++ b/.github/workflows/release-sdk-to-candidate.yml
@@ -36,7 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: "2204 Branch"
     strategy:
-      fail-fast: false
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
     steps:


### PR DESCRIPTION
## Summary
- remove explicit `fail-fast: false` from release matrix strategies
- let GitHub Actions use the default fail-fast behavior for release jobs

## Verification
- confirmed no remaining `fail-fast: false` in `.github/workflows`
- compared org-wide code search for `fail-fast: false` in workflow files; these SDK/content release workflows are among the small set of outliers in Snapcrafters