### PR TITLE
docs: standardise workflow names and badges [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="https://snapcraft.io/ffmpeg-2204-sdk"><img src="https://snapcraft.io/ffmpeg-2204-sdk/badge.svg" alt="FFmpeg SDK Status"></a>
 <a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/update-sdk-snap.yml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/update-sdk-snap.yml/badge.svg"></a>
 
-<a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-sdk-to-candidate.yaml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-sdk-to-candidate.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-sdk-to-candidate.yml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-sdk-to-candidate.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </ul>
 
@@ -19,7 +19,7 @@
 <ul>
 <a href="https://snapcraft.io/ffmpeg-2204"><img src="https://snapcraft.io/ffmpeg-2204/badge.svg" alt="FFmpeg Content Snap Status"></a>
 <a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/update-sdk-snap.yml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/update-sdk-snap.yml/badge.svg"></a>
-<a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-content-to-candidate.yaml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-content-to-candidate.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-content-to-candidate.yml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/release-content-to-candidate.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/ffmpeg-2204-sdk/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </ul>
 


### PR DESCRIPTION
## Summary
- Standardises workflow filenames and README workflow badge links on `2204`.
- Keeps badge href and image URLs aligned with workflow files present on this branch.

## Workflow renames
- None

## README files
- `README.md`

## Badge/link replacements
- `release-content-to-candidate.yaml -> release-content-to-candidate.yml`
- `release-sdk-to-candidate.yaml -> release-sdk-to-candidate.yml`

## Verification
- `git diff --check`
- Commit message includes `[skip ci]`.

@jnsgruk please review.
